### PR TITLE
refactor: delivery option rename, now uses option.title string match

### DIFF
--- a/app/routes/app.delivery-option-hide.$functionId.$id.tsx
+++ b/app/routes/app.delivery-option-hide.$functionId.$id.tsx
@@ -65,8 +65,9 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   return {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      stateProvinceCode: "",
-      message: "",
+      customPropKey: "",
+      customPropType: "",
+      shipOptionTitleMatch: "",
     }),
   };
 };

--- a/app/routes/app.delivery-option-rename.$functionId.$id.tsx
+++ b/app/routes/app.delivery-option-rename.$functionId.$id.tsx
@@ -54,7 +54,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     return {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        stateProvinceCode: metafieldValue.stateProvinceCode,
+        shipOptionTitleMatch: metafieldValue.shipOptionTitleMatch,
         message: metafieldValue.message,
       }),
     };
@@ -63,7 +63,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   return {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      stateProvinceCode: "",
+      shipOptionTitleMatch: "",
       message: "",
     }),
   };
@@ -74,12 +74,14 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
   const { admin } = await authenticate.admin(request);
   const formData = await request.formData();
 
-  const stateProvinceCode = formData.get("stateProvinceCode");
+  const shipOptionTitleMatch = formData.get("shipOptionTitleMatch");
   const message = formData.get("message");
+
+  const title = `Change ${shipOptionTitleMatch} delivery message`;
 
   const deliveryCustomizationInput = {
     functionId,
-    title: `Change ${stateProvinceCode} delivery message`,
+    title,
     enabled: true,
     metafields: [
       {
@@ -87,7 +89,7 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
         key: "function-configuration",
         type: "json",
         value: JSON.stringify({
-          stateProvinceCode,
+          shipOptionTitleMatch,
           message,
         }),
       },
@@ -154,15 +156,15 @@ export default function DeliveryCustomization() {
   const navigation = useNavigation();
   const loaderData = useLoaderData<any>();
 
-  const [stateProvinceCode, setStateProvinceCode] = useState(
-    loaderData.stateProvinceCode,
+  const [shipOptionTitleMatch, setShipOptionTitleMatch] = useState(
+    loaderData.shipOptionTitleMatch,
   );
   const [message, setMessage] = useState(loaderData.message);
 
   useEffect(() => {
     if (loaderData) {
       const parsedData = JSON.parse(loaderData.body);
-      setStateProvinceCode(parsedData.stateProvinceCode);
+      setShipOptionTitleMatch(parsedData.shipOptionTitleMatch);
       setMessage(parsedData.message);
     }
   }, [loaderData]);
@@ -194,7 +196,7 @@ export default function DeliveryCustomization() {
   ) : null;
 
   const handleSubmit = () => {
-    submit({ stateProvinceCode, message }, { method: "post" });
+    submit({ shipOptionTitleMatch, message }, { method: "post" });
   };
 
   return (
@@ -228,11 +230,11 @@ export default function DeliveryCustomization() {
               <FormLayout>
                 <FormLayout.Group>
                   <TextField
-                    name="stateProvinceCode"
+                    name="shipOptionTitleMatch"
                     type="text"
-                    label="State/Province code"
-                    value={stateProvinceCode}
-                    onChange={setStateProvinceCode}
+                    label="Ship Option Title Match"
+                    value={shipOptionTitleMatch}
+                    onChange={setShipOptionTitleMatch}
                     disabled={isLoading}
                     requiredIndicator
                     autoComplete="on"

--- a/extensions/delivery-option-hide/src/run.ts
+++ b/extensions/delivery-option-hide/src/run.ts
@@ -51,7 +51,7 @@ export function run(input: { deliveryCustomization: any; cart?: any }) {
   const hasMatch =
     propType === "line_item" ? hasLineCustomAttribute : hasCustomAttribute;
 
-  let toRename = input.cart.deliveryGroups
+  let toRemove = input.cart.deliveryGroups
     .flatMap((group: { deliveryOptions: any }) => group.deliveryOptions)
     .filter((option: { handle: any; title: any }) => {
       console.log("TITLE", option.title);
@@ -70,6 +70,6 @@ export function run(input: { deliveryCustomization: any; cart?: any }) {
     }));
 
   return {
-    operations: toRename,
+    operations: toRemove,
   };
 }

--- a/extensions/delivery-option-rename/src/run.ts
+++ b/extensions/delivery-option-rename/src/run.ts
@@ -1,50 +1,53 @@
 // @ts-check
 
 /**
-* @typedef {import("../generated/api").RunInput} RunInput
-* @typedef {import("../generated/api").FunctionRunResult} FunctionRunResult
-* @typedef {import("../generated/api").Operation} Operation
-*/
+ * @typedef {import("../generated/api").RunInput} RunInput
+ * @typedef {import("../generated/api").FunctionRunResult} FunctionRunResult
+ * @typedef {import("../generated/api").Operation} Operation
+ */
 /**
-* @type {FunctionRunResult}
-*/
+ * @type {FunctionRunResult}
+ */
 const NO_CHANGES = {
   operations: [],
 };
 
 /**
-* @param {RunInput} input
-* @returns {FunctionRunResult}
-*/
-export function run(input: { deliveryCustomization: any; cart?: any; }) {
+ * @param {RunInput} input
+ * @returns {FunctionRunResult}
+ */
+export function run(input: { deliveryCustomization: any; cart?: any }) {
   // Define a type for your configuration, and parse it from the metafield
   /**
-  * @type {{
-  *  stateProvinceCode: string
-  *  message: number
-  * }}
-  */
+   * @type {{
+   *  shipOptionTitleMatch: string
+   *  message: number
+   * }}
+   */
   const configuration = JSON.parse(
-    input?.deliveryCustomization?.metafield?.value ?? "{}"
+    input?.deliveryCustomization?.metafield?.value ?? "{}",
   );
-  if (!configuration.stateProvinceCode || !configuration.message) {
+  if (!configuration.shipOptionTitleMatch || !configuration.message) {
     return NO_CHANGES;
   }
 
+  const titleMatch = configuration.shipOptionTitleMatch;
+  const message = configuration.message;
+
   let toRename = input.cart.deliveryGroups
-    .filter((group: { deliveryAddress: { provinceCode: any; }; }) => group.deliveryAddress?.provinceCode &&
-      // Use the configured province code instead of a hardcoded value
-      group.deliveryAddress.provinceCode == configuration.stateProvinceCode)
-    .flatMap((group: { deliveryOptions: any; }) => group.deliveryOptions)
-    .map((option: { handle: any; title: any; }) => /** @type {Operation} */({
+    .flatMap((group: { deliveryOptions: any }) => group.deliveryOptions)
+    .filter((option: { handle: any; title: any }) => {
+      return option.title.toLowerCase().includes(titleMatch.toLowerCase());
+    })
+    .map((option: { handle: any; title: any }) => /** @type {Operation} */ ({
       rename: {
         deliveryOptionHandle: option.handle,
         // Use the configured message instead of a hardcoded value
-        title: option.title ? `${option.title} - ${configuration.message}` : configuration.message
-      }
+        title: option.title ? `${option.title} - ${message}` : message,
+      },
     }));
 
   return {
-    operations: toRename
+    operations: toRename,
   };
-};
+}

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -3,7 +3,7 @@
 client_id = "7431687ef99661f19e161a30ac9527fa"
 name = "Suavecito Functions"
 handle = "suavecito-functions"
-application_url = "https://locate-disposition-vessel-strength.trycloudflare.com"
+application_url = "https://instead-timing-boundaries-gm.trycloudflare.com"
 embedded = true
 
 [build]
@@ -17,9 +17,9 @@ scopes = "write_delivery_customizations,write_products"
 
 [auth]
 redirect_urls = [
-  "https://locate-disposition-vessel-strength.trycloudflare.com/auth/callback",
-  "https://locate-disposition-vessel-strength.trycloudflare.com/auth/shopify/callback",
-  "https://locate-disposition-vessel-strength.trycloudflare.com/api/auth/callback"
+  "https://instead-timing-boundaries-gm.trycloudflare.com/auth/callback",
+  "https://instead-timing-boundaries-gm.trycloudflare.com/auth/shopify/callback",
+  "https://instead-timing-boundaries-gm.trycloudflare.com/api/auth/callback"
 ]
 
 [webhooks]


### PR DESCRIPTION
This PR updates the deliver option rename function to use an option title string match instead of a delivery address state match.