### PR TITLE
Collections

### DIFF
--- a/extensions/buy-x-get-y-product-discount/shopify.extension.toml
+++ b/extensions/buy-x-get-y-product-discount/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "buy-x-get-y-product-discount"

--- a/extensions/delivery-option-hide/shopify.extension.toml
+++ b/extensions/delivery-option-hide/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "delivery-option-hide"

--- a/extensions/delivery-option-rename/shopify.extension.toml
+++ b/extensions/delivery-option-rename/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "delivery-option-rename"

--- a/extensions/product-discount/shopify.extension.toml
+++ b/extensions/product-discount/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 handle = "product-discount"

--- a/extensions/product-discount/src/run.ts
+++ b/extensions/product-discount/src/run.ts
@@ -50,6 +50,12 @@ export function run(input: RunInput) {
   // to filter out subscriptions, we can use line.sellingPlanAllocation
   const targets = input.cart.lines
     // Use the configured quantity instead of a hardcoded value
+    // Exclude lines that are in any collection
+    .filter(
+      (line) =>
+        line.merchandise.__typename == "ProductVariant" &&
+        !line.merchandise.product.inAnyCollection,
+    )
     .filter(
       (line) =>
         line.quantity >= configuration.quantity &&


### PR DESCRIPTION
I have updated the Suavecito Functions - Product Discounts Extension to check if the line item (product variant) is part of a collection. If so then exclude it from current discount. This would be another fallback, for example all Clearance items should already have the metafield set to exclude from discount, but this would exclude them as well since they would belong to the Clearance collection.