### PR TITLE
v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ## Unreleased
 
+## v0.0.6 = 2025-09-12
+
+**Breaking Changes**
+
+- The FREE Shipping Discount can now be excluded by variant metafield.
+  - A variant can be excluded from the FREE Shipping discount by setting the `Free Shipping Country Exclusions` variant metafield. \*\* This will exclude the whole order from free shipping if the variant is in the cart.
+
 ## v0.0.5 - 2025-07-31
 
 **Breaking Changes**
@@ -40,7 +47,7 @@
 - Buy X Get Y Product Discount
   - This function creates a simple (really basic) Buy X Get Y product discount
   - The function takes 3 arguments: Buy X (number of products), Get Y (number of products), and Percentage (discount percentage)
-  - The function will handle the rest of the logic. Including the discount split. Eligible products depend on a variant metafield: `variant.metafields.debut.enable_b2g1f` \*\* metafield namespace and key could change
+  - The function will handle the rest of the logic. Including the discount split.
     - Ex: Buy 2 Get 1 Free. Input = 5 eligible products, Discount Split = 4 Paid, 1 Free.
     - Ex: Buy 2 Get 1 Free. Input = 6 eligible products, Discount Split = 4 Paid, 2 Free.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,32 @@
 
 [Shopify Functions Overview](https://shopify.dev/docs/apps/functions)
 
+This app depends on 2 variant metafields:
+
+<table>
+  <tr>
+    <th>Namespace</th>
+    <th>Key</th>
+    <th>Description</th>
+    <th>Type</th>
+    <th>Example Value(s)</th>
+  </tr>
+  <tr>
+    <td>suavecito_function</td>
+    <td>exclude_from_all_discounts</td>
+    <td>Exclude variant from all discounts created by the Suavecito Functions App.</td>
+    <td>Boolean</td>
+    <td>true</td>
+  </tr>
+  <tr>
+    <td>suavecito_function</td>
+    <td>free_shipping_country_exclusions</td>
+    <td>Exclude variant from free shipping to specific countries.</td>
+    <td>Single Line Text (Reference List)</td>
+    <td>CA, MX, US</td>
+  </tr>
+</table>
+
 ## Dev
 
 ```bash
@@ -83,7 +109,7 @@ Buy X Get Y Product Discount (Percent Off)
 
 - This function creates a simple (really basic) Buy X Get Y product discount
 - The function takes 3 arguments: Buy X (number of products), Get Y (number of products), and Percentage (discount percentage)
-- The function will handle the rest of the logic. Including the discount split. Eligible products depend on a variant metafield: `variant.metafields.debut.enable_b2g1f` \*\* metafield namespace and key could change
+- The function will handle the rest of the logic. Including the discount split.
   - Ex: Buy 2 Get 1 Free. Input = 5 eligible products, Discount Split = 4 Paid, 1 Free.
   - Ex: Buy 2 Get 1 Free. Input = 6 eligible products, Discount Split = 4 Paid, 2 Free.
 

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -14,7 +14,7 @@ import {
 } from "@shopify/polaris";
 import { authenticate } from "../shopify.server";
 
-const version = "v0.0.5";
+const version = "v0.0.6";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);
@@ -144,10 +144,7 @@ export default function Index() {
                       </List.Item>
                       <List.Item>
                         The function will handle the rest of the logic.
-                        Including the discount split. Eligible products depend
-                        on a variant metafield:{" "}
-                        <strong>variant.metafields.debut.enable_b2g1f</strong>{" "}
-                        <i>** metafield namespace and key could change</i>
+                        Including the discount split.
                       </List.Item>
                     </List>
                   </BlockStack>
@@ -179,6 +176,13 @@ export default function Index() {
                         priced shipping option from the currently available
                         options, and it will discount it by the selected
                         discount percentage
+                      </List.Item>
+                      <List.Item>
+                        A variant can be excluded from the FREE Shipping
+                        discount by setting the `Free Shipping Country
+                        Exclusions` variant metafield. ** This will exclude the
+                        whole order from free shipping if the variant is in the
+                        cart.
                       </List.Item>
                       <List.Item>
                         <strong>Example use case: </strong>

--- a/extensions/shipping-discount/src/run.ts
+++ b/extensions/shipping-discount/src/run.ts
@@ -69,7 +69,11 @@ export function run(input: RunInput): FunctionRunResult {
     "FREE SHIPPING EXCLUDED SHIP COUNTRIES",
     freeShippingExcludedShipCountries,
   );
-  if (freeShippingExcludedShipCountries.includes(shipCountryCode!)) {
+  // if the current ship country is in the list of excluded countries, do not apply the FREE shipping discount
+  if (
+    percentage === 100 &&
+    freeShippingExcludedShipCountries.includes(shipCountryCode!)
+  ) {
     console.log("COUNTRY IS EXCLUDED FROM FREE SHIPPING BY VARIANT METAFIELD");
     return EMPTY_DISCOUNT;
   }


### PR DESCRIPTION
**Breaking Changes**

- The FREE Shipping Discount can now be excluded by variant metafield.
  - A variant can be excluded from the FREE Shipping discount by setting the `Free Shipping Country Exclusions` variant metafield.  **This will exclude the whole order from free shipping if the variant is in the cart.